### PR TITLE
feat: Add simple timeline and history commands for infrastructure snapshots

### DIFF
--- a/cmd/vaino/commands/history.go
+++ b/cmd/vaino/commands/history.go
@@ -1,0 +1,336 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/yairfalse/vaino/internal/storage"
+	"github.com/yairfalse/vaino/pkg/types"
+)
+
+func newHistoryCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "history",
+		Short: "Browse infrastructure history and snapshots",
+		Long: `Browse stored infrastructure snapshots and history.
+Provides detailed view of individual snapshots and their contents.`,
+		Example: `  # List all snapshots
+  vaino history
+
+  # List snapshots since a date
+  vaino history --since "june-1"
+
+  # Show details of a specific snapshot
+  vaino history show snapshot-id
+
+  # List snapshots in JSON format
+  vaino history --output json
+
+  # Show snapshot with resource details
+  vaino history show --details snapshot-id`,
+		RunE: runHistory,
+	}
+
+	// Add subcommands
+	cmd.AddCommand(newHistoryShowCommand())
+	cmd.AddCommand(newHistoryListCommand())
+
+	// Date/time filters for default list behavior
+	cmd.Flags().StringP("since", "s", "", "show history since date/duration")
+	cmd.Flags().StringP("until", "u", "", "show history until date")
+	cmd.Flags().StringSlice("provider", nil, "filter by provider")
+	cmd.Flags().IntP("limit", "l", 20, "limit number of snapshots shown")
+	cmd.Flags().BoolP("quiet", "q", false, "quiet mode - show IDs only")
+
+	return cmd
+}
+
+func runHistory(cmd *cobra.Command, args []string) error {
+	// Default behavior: list snapshots
+	return runHistoryList(cmd, args)
+}
+
+func newHistoryListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List stored snapshots",
+		Long:  `List all stored infrastructure snapshots with filtering options.`,
+		RunE:  runHistoryList,
+	}
+
+	cmd.Flags().StringP("since", "s", "", "show snapshots since date/duration")
+	cmd.Flags().StringP("until", "u", "", "show snapshots until date")
+	cmd.Flags().StringSlice("provider", nil, "filter by provider")
+	cmd.Flags().IntP("limit", "l", 20, "limit number of snapshots shown")
+	cmd.Flags().BoolP("quiet", "q", false, "quiet mode - show IDs only")
+
+	return cmd
+}
+
+func newHistoryShowCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show [snapshot-id]",
+		Short: "Show details of a specific snapshot",
+		Long: `Show detailed information about a specific snapshot including
+resource counts, metadata, and optionally full resource details.`,
+		Args: cobra.ExactArgs(1),
+		RunE: runHistoryShow,
+	}
+
+	cmd.Flags().BoolP("details", "d", false, "show full resource details")
+	cmd.Flags().StringSlice("resource-type", nil, "filter resources by type")
+	cmd.Flags().StringSlice("region", nil, "filter resources by region")
+
+	return cmd
+}
+
+func runHistoryList(cmd *cobra.Command, args []string) error {
+	cfg := GetConfig()
+
+	// Initialize storage
+	localStorage := storage.NewLocal(cfg.Storage.BasePath)
+
+	// Get all snapshots
+	snapshots, err := localStorage.ListSnapshots()
+	if err != nil {
+		return fmt.Errorf("failed to list snapshots: %w", err)
+	}
+
+	if len(snapshots) == 0 {
+		fmt.Println("No snapshots found. Run 'vaino scan' to create your first snapshot.")
+		return nil
+	}
+
+	// Parse filter options - reuse from timeline.go
+	sinceTime, err := parseTimeFilter(cmd, "since")
+	if err != nil {
+		return fmt.Errorf("invalid --since value: %w", err)
+	}
+
+	untilTime, err := parseTimeFilter(cmd, "until")
+	if err != nil {
+		return fmt.Errorf("invalid --until value: %w", err)
+	}
+
+	providers, _ := cmd.Flags().GetStringSlice("provider")
+	limit, _ := cmd.Flags().GetInt("limit")
+	quiet, _ := cmd.Flags().GetBool("quiet")
+
+	// Filter snapshots - reuse from timeline.go
+	filteredSnapshots := filterSnapshots(snapshots, sinceTime, untilTime, "", "", providers)
+
+	// Limit results
+	if limit > 0 && len(filteredSnapshots) > limit {
+		filteredSnapshots = filteredSnapshots[:limit]
+	}
+
+	// Sort by timestamp (newest first for history view)
+	sort.Slice(filteredSnapshots, func(i, j int) bool {
+		return filteredSnapshots[i].Timestamp.After(filteredSnapshots[j].Timestamp)
+	})
+
+	// Get output format
+	outputFormat, _ := cmd.Flags().GetString("output")
+
+	return displayHistoryList(filteredSnapshots, outputFormat, quiet)
+}
+
+func runHistoryShow(cmd *cobra.Command, args []string) error {
+	cfg := GetConfig()
+	snapshotID := args[0]
+
+	// Initialize storage
+	localStorage := storage.NewLocal(cfg.Storage.BasePath)
+
+	// Load the snapshot
+	snapshot, err := localStorage.LoadSnapshot(snapshotID)
+	if err != nil {
+		return fmt.Errorf("failed to load snapshot %s: %w", snapshotID, err)
+	}
+
+	// Get options
+	showDetails, _ := cmd.Flags().GetBool("details")
+	resourceTypes, _ := cmd.Flags().GetStringSlice("resource-type")
+	regions, _ := cmd.Flags().GetStringSlice("region")
+	outputFormat, _ := cmd.Flags().GetString("output")
+
+	return displaySnapshotDetails(snapshot, outputFormat, showDetails, resourceTypes, regions)
+}
+
+func displayHistoryList(snapshots []storage.SnapshotInfo, outputFormat string, quiet bool) error {
+	if outputFormat == "json" {
+		return historyOutputJSON(snapshots)
+	}
+
+	if quiet {
+		for _, snapshot := range snapshots {
+			fmt.Println(snapshot.ID)
+		}
+		return nil
+	}
+
+	// Default text format
+	fmt.Printf("Infrastructure History (%d snapshots)\n", len(snapshots))
+	fmt.Println(strings.Repeat("=", 60))
+	fmt.Println()
+
+	// Display in table format
+	fmt.Printf("%-25s %-12s %-12s %-8s %-10s\n", "TIMESTAMP", "PROVIDER", "ID", "RESOURCES", "SIZE")
+	fmt.Println(strings.Repeat("-", 80))
+
+	for _, snapshot := range snapshots {
+		fmt.Printf("%-25s %-12s %-12s %-8d %-10s\n",
+			snapshot.Timestamp.Format("2006-01-02 15:04:05"),
+			snapshot.Provider,
+			truncateString(snapshot.ID, 12),
+			snapshot.ResourceCount,
+			formatFileSize(snapshot.FileSize))
+	}
+
+	return nil
+}
+
+func displaySnapshotDetails(snapshot *types.Snapshot, outputFormat string, showDetails bool, resourceTypes, regions []string) error {
+	if outputFormat == "json" {
+		if !showDetails {
+			// Return summary version
+			summary := struct {
+				ID            string            `json:"id"`
+				Timestamp     time.Time         `json:"timestamp"`
+				Provider      string            `json:"provider"`
+				ResourceCount int               `json:"resource_count"`
+				Metadata      map[string]string `json:"metadata"`
+			}{
+				ID:            snapshot.ID,
+				Timestamp:     snapshot.Timestamp,
+				Provider:      snapshot.Provider,
+				ResourceCount: len(snapshot.Resources),
+				Metadata:      snapshot.Metadata.Tags,
+			}
+			return historyOutputJSON(summary)
+		}
+		return historyOutputJSON(snapshot)
+	}
+
+	// Text format
+	fmt.Printf("Snapshot Details\n")
+	fmt.Println(strings.Repeat("=", 30))
+	fmt.Printf("ID:          %s\n", snapshot.ID)
+	fmt.Printf("Timestamp:   %s\n", snapshot.Timestamp.Format("2006-01-02 15:04:05 MST"))
+	fmt.Printf("Provider:    %s\n", snapshot.Provider)
+	fmt.Printf("Resources:   %d\n", len(snapshot.Resources))
+
+	if len(snapshot.Metadata.Tags) > 0 {
+		fmt.Printf("Tags:        ")
+		var tags []string
+		for k, v := range snapshot.Metadata.Tags {
+			tags = append(tags, fmt.Sprintf("%s=%s", k, v))
+		}
+		fmt.Printf("%s\n", strings.Join(tags, ", "))
+	}
+
+	fmt.Println()
+
+	// Resource summary by type and region
+	resourcesByType := make(map[string]int)
+	resourcesByRegion := make(map[string]int)
+
+	for _, resource := range snapshot.Resources {
+		resourcesByType[resource.Type]++
+		if resource.Region != "" {
+			resourcesByRegion[resource.Region]++
+		}
+	}
+
+	fmt.Println("Resource Summary")
+	fmt.Println(strings.Repeat("-", 20))
+
+	fmt.Println("By Type:")
+	for resourceType, count := range resourcesByType {
+		fmt.Printf("  %-20s %d\n", resourceType, count)
+	}
+
+	if len(resourcesByRegion) > 0 {
+		fmt.Println("\nBy Region:")
+		for region, count := range resourcesByRegion {
+			fmt.Printf("  %-20s %d\n", region, count)
+		}
+	}
+
+	// Show detailed resource list if requested
+	if showDetails {
+		fmt.Println()
+		displayResourceDetails(snapshot.Resources, resourceTypes, regions)
+	}
+
+	return nil
+}
+
+func displayResourceDetails(resources []types.Resource, resourceTypeFilter, regionFilter []string) {
+	// Create filter maps
+	typeFilter := make(map[string]bool)
+	for _, t := range resourceTypeFilter {
+		typeFilter[strings.ToLower(t)] = true
+	}
+
+	regFilter := make(map[string]bool)
+	for _, r := range regionFilter {
+		regFilter[strings.ToLower(r)] = true
+	}
+
+	fmt.Println("Resource Details")
+	fmt.Println(strings.Repeat("-", 20))
+	fmt.Printf("%-20s %-30s %-15s %-15s\n", "TYPE", "NAME", "REGION", "ID")
+	fmt.Println(strings.Repeat("-", 80))
+
+	for _, resource := range resources {
+		// Apply filters
+		if len(typeFilter) > 0 && !typeFilter[strings.ToLower(resource.Type)] {
+			continue
+		}
+		if len(regFilter) > 0 && !regFilter[strings.ToLower(resource.Region)] {
+			continue
+		}
+
+		fmt.Printf("%-20s %-30s %-15s %-15s\n",
+			truncateString(resource.Type, 20),
+			truncateString(resource.Name, 30),
+			resource.Region,
+			truncateString(resource.ID, 15))
+	}
+}
+
+// Helper functions
+func truncateString(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+func formatFileSize(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}
+
+// historyOutputJSON outputs data as pretty-printed JSON (unique name to avoid conflicts)
+func historyOutputJSON(data interface{}) error {
+	jsonData, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	fmt.Println(string(jsonData))
+	return nil
+}

--- a/cmd/vaino/commands/root.go
+++ b/cmd/vaino/commands/root.go
@@ -87,6 +87,8 @@ func init() {
 	rootCmd.AddCommand(newSimpleDiffCommand()) // New simple changes command
 	rootCmd.AddCommand(newWatchCommand())      // Real-time watch mode
 	rootCmd.AddCommand(catchUpCmd)             // Empathetic catch-up summary
+	rootCmd.AddCommand(newTimelineCommand())   // Timeline view of snapshots
+	rootCmd.AddCommand(newHistoryCommand())    // History browsing
 	rootCmd.AddCommand(newAuthCommand())
 	rootCmd.AddCommand(newVersionCommand())
 	rootCmd.AddCommand(newConfigureCommand())   // Configuration wizard

--- a/cmd/vaino/commands/timeline.go
+++ b/cmd/vaino/commands/timeline.go
@@ -1,0 +1,307 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/yairfalse/vaino/internal/storage"
+)
+
+func newTimelineCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "timeline",
+		Short: "Browse infrastructure snapshots chronologically",
+		Long: `Browse stored infrastructure snapshots in chronological order.
+This provides a simple view of when snapshots were taken and basic statistics.
+
+For advanced change timeline with correlation analysis, use: vaino changes --timeline
+For change comparison between snapshots, use: vaino diff`,
+		Example: `  # Show snapshot timeline
+  vaino timeline
+
+  # Show snapshots from last 2 weeks
+  vaino timeline --since "2 weeks ago"
+
+  # Show snapshots for specific provider
+  vaino timeline --provider kubernetes
+
+  # Export timeline as JSON
+  vaino timeline --output json`,
+		RunE: runTimeline,
+	}
+
+	// Date/time filters
+	cmd.Flags().StringP("since", "s", "", "show snapshots since date/duration (e.g., '2 weeks ago', '2024-01-01')")
+	cmd.Flags().StringP("until", "u", "", "show snapshots until date (e.g., '2024-01-31')")
+
+	// Provider filters
+	cmd.Flags().StringSlice("provider", nil, "filter by provider (aws, gcp, kubernetes, terraform)")
+
+	// Output options
+	cmd.Flags().BoolP("stats", "", false, "show snapshot statistics")
+	cmd.Flags().BoolP("quiet", "q", false, "quiet mode - show timestamps only")
+	cmd.Flags().IntP("limit", "l", 50, "limit number of snapshots shown")
+
+	return cmd
+}
+
+func runTimeline(cmd *cobra.Command, args []string) error {
+	cfg := GetConfig()
+
+	// Initialize storage
+	localStorage := storage.NewLocal(cfg.Storage.BasePath)
+
+	// Get all snapshots
+	snapshots, err := localStorage.ListSnapshots()
+	if err != nil {
+		return fmt.Errorf("failed to list snapshots: %w", err)
+	}
+
+	if len(snapshots) == 0 {
+		fmt.Println("No snapshots found. Run 'vaino scan' to create your first snapshot.")
+		return nil
+	}
+
+	// Parse filter options
+	sinceTime, err := parseTimeFilter(cmd, "since")
+	if err != nil {
+		return fmt.Errorf("invalid --since value: %w", err)
+	}
+
+	untilTime, err := parseTimeFilter(cmd, "until")
+	if err != nil {
+		return fmt.Errorf("invalid --until value: %w", err)
+	}
+
+	providers, _ := cmd.Flags().GetStringSlice("provider")
+	showStats, _ := cmd.Flags().GetBool("stats")
+	quiet, _ := cmd.Flags().GetBool("quiet")
+	limit, _ := cmd.Flags().GetInt("limit")
+
+	// Filter snapshots
+	filteredSnapshots := filterSnapshots(snapshots, sinceTime, untilTime, "", "", providers)
+
+	// Limit results
+	if limit > 0 && len(filteredSnapshots) > limit {
+		filteredSnapshots = filteredSnapshots[:limit]
+	}
+
+	// Get output format
+	outputFormat, _ := cmd.Flags().GetString("output")
+
+	// Display timeline
+	return displaySnapshotTimeline(filteredSnapshots, outputFormat, showStats, quiet)
+}
+
+func parseTimeFilter(cmd *cobra.Command, flagName string) (*time.Time, error) {
+	value, _ := cmd.Flags().GetString(flagName)
+	if value == "" {
+		return nil, nil
+	}
+
+	// Try parsing as duration first (e.g., "2 weeks ago", "3 days ago")
+	if strings.Contains(value, "ago") {
+		return parseDurationAgo(value)
+	}
+
+	// Try parsing as date
+	formats := []string{
+		"2006-01-02",
+		"2006-01-02T15:04:05",
+		"2006-01-02T15:04:05Z",
+		time.RFC3339,
+	}
+
+	for _, format := range formats {
+		if t, err := time.Parse(format, value); err == nil {
+			return &t, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unable to parse time: %s", value)
+}
+
+func parseDurationAgo(value string) (*time.Time, error) {
+	// Simple parser for durations like "2 weeks ago", "3 days ago"
+	parts := strings.Fields(value)
+	if len(parts) < 3 || parts[len(parts)-1] != "ago" {
+		return nil, fmt.Errorf("invalid duration format: %s", value)
+	}
+
+	amountStr := parts[0]
+	unit := parts[1]
+
+	amount, err := strconv.Atoi(amountStr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid amount: %s", amountStr)
+	}
+
+	var duration time.Duration
+	switch strings.ToLower(unit) {
+	case "minute", "minutes":
+		duration = time.Duration(amount) * time.Minute
+	case "hour", "hours":
+		duration = time.Duration(amount) * time.Hour
+	case "day", "days":
+		duration = time.Duration(amount) * 24 * time.Hour
+	case "week", "weeks":
+		duration = time.Duration(amount) * 7 * 24 * time.Hour
+	case "month", "months":
+		duration = time.Duration(amount) * 30 * 24 * time.Hour
+	default:
+		return nil, fmt.Errorf("unsupported time unit: %s", unit)
+	}
+
+	t := time.Now().Add(-duration)
+	return &t, nil
+}
+
+func filterSnapshots(snapshots []storage.SnapshotInfo, since, until *time.Time, fromID, toID string, providers []string) []storage.SnapshotInfo {
+	var filtered []storage.SnapshotInfo
+
+	// Create provider filter map
+	providerFilter := make(map[string]bool)
+	for _, p := range providers {
+		providerFilter[strings.ToLower(p)] = true
+	}
+
+	for _, snapshot := range snapshots {
+		// Time filters
+		if since != nil && snapshot.Timestamp.Before(*since) {
+			continue
+		}
+		if until != nil && snapshot.Timestamp.After(*until) {
+			continue
+		}
+
+		// Provider filter
+		if len(providerFilter) > 0 && !providerFilter[strings.ToLower(snapshot.Provider)] {
+			continue
+		}
+
+		filtered = append(filtered, snapshot)
+	}
+
+	// Sort by timestamp (oldest first for timeline view)
+	sort.Slice(filtered, func(i, j int) bool {
+		return filtered[i].Timestamp.Before(filtered[j].Timestamp)
+	})
+
+	return filtered
+}
+
+func displaySnapshotTimeline(snapshots []storage.SnapshotInfo, outputFormat string, showStats, quiet bool) error {
+	if outputFormat == "json" {
+		return timelineOutputJSON(snapshots)
+	}
+
+	if quiet {
+		return displayTimelineQuiet(snapshots)
+	}
+
+	// Default text format
+	fmt.Printf("Infrastructure Snapshot Timeline (%d snapshots)\n", len(snapshots))
+	fmt.Println(strings.Repeat("=", 60))
+	fmt.Println()
+
+	for _, snapshot := range snapshots {
+		fmt.Printf("📅 %s\n", snapshot.Timestamp.Format("2006-01-02 15:04:05"))
+		fmt.Printf("   Provider: %s\n", snapshot.Provider)
+		fmt.Printf("   Resources: %d\n", snapshot.ResourceCount)
+		fmt.Printf("   ID: %s\n", snapshot.ID)
+
+		if len(snapshot.Tags) > 0 {
+			fmt.Print("   Tags: ")
+			var tags []string
+			for k, v := range snapshot.Tags {
+				tags = append(tags, fmt.Sprintf("%s=%s", k, v))
+			}
+			fmt.Println(strings.Join(tags, ", "))
+		}
+		fmt.Println()
+	}
+
+	if showStats {
+		displaySnapshotStats(snapshots)
+	}
+
+	fmt.Println("💡 For advanced change timeline with correlation analysis, use:")
+	fmt.Println("   vaino changes --timeline")
+
+	return nil
+}
+
+func timelineOutputJSON(snapshots []storage.SnapshotInfo) error {
+	// Convert to a simple JSON structure
+	type TimelineEntry struct {
+		Timestamp     time.Time         `json:"timestamp"`
+		Provider      string            `json:"provider"`
+		ResourceCount int               `json:"resource_count"`
+		ID            string            `json:"id"`
+		Tags          map[string]string `json:"tags,omitempty"`
+	}
+
+	var entries []TimelineEntry
+	for _, snapshot := range snapshots {
+		entries = append(entries, TimelineEntry{
+			Timestamp:     snapshot.Timestamp,
+			Provider:      snapshot.Provider,
+			ResourceCount: snapshot.ResourceCount,
+			ID:            snapshot.ID,
+			Tags:          snapshot.Tags,
+		})
+	}
+
+	jsonData, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+	fmt.Println(string(jsonData))
+	return nil
+}
+
+func displayTimelineQuiet(snapshots []storage.SnapshotInfo) error {
+	for _, snapshot := range snapshots {
+		fmt.Printf("%s %s %d\n",
+			snapshot.Timestamp.Format("2006-01-02T15:04:05"),
+			snapshot.Provider,
+			snapshot.ResourceCount)
+	}
+	return nil
+}
+
+func displaySnapshotStats(snapshots []storage.SnapshotInfo) {
+	if len(snapshots) == 0 {
+		return
+	}
+
+	fmt.Println("Snapshot Statistics")
+	fmt.Println(strings.Repeat("-", 30))
+
+	// Provider distribution
+	providers := make(map[string]int)
+	totalResources := 0
+
+	for _, snapshot := range snapshots {
+		providers[snapshot.Provider]++
+		totalResources += snapshot.ResourceCount
+	}
+
+	fmt.Printf("Total snapshots: %d\n", len(snapshots))
+	fmt.Printf("Date range: %s to %s\n",
+		snapshots[0].Timestamp.Format("2006-01-02"),
+		snapshots[len(snapshots)-1].Timestamp.Format("2006-01-02"))
+	fmt.Printf("Total resources: %d\n", totalResources)
+	fmt.Printf("Average resources per snapshot: %.1f\n", float64(totalResources)/float64(len(snapshots)))
+
+	fmt.Println("\nProvider distribution:")
+	for provider, count := range providers {
+		fmt.Printf("  %s: %d snapshots\n", provider, count)
+	}
+	fmt.Println()
+}


### PR DESCRIPTION
## Summary

Add complementary snapshot browsing commands that work alongside existing timeline functionality:

- `vaino timeline`: Chronological view of stored snapshots with filtering
- `vaino history`: Browse and inspect snapshot details  
- `vaino history show <id>`: Detailed snapshot inspection

## Features

✅ **File-based implementation** using existing storage system  
✅ **Date filtering** (--since "2 weeks ago", --until)  
✅ **Provider filtering** (--provider kubernetes)  
✅ **Multiple output formats** (text, JSON, quiet mode)  
✅ **Statistics and resource breakdowns**  
✅ **Unix-style output** for scripting  

## Smart Integration

Complements existing `vaino changes --timeline` for advanced correlation analysis while providing simple snapshot browsing capabilities:

- **For basic snapshot browsing**: Use new `vaino timeline` / `vaino history`
- **For advanced change analysis**: Use existing `vaino changes --timeline`  
- **For correlation analysis**: Use existing analyzer system

## Test plan

- [x] Build compiles without errors
- [x] Code formatted with gofmt  
- [x] Agent management workflow completed
- [x] Commands integrate with existing storage system
- [x] No duplicate functionality

## Usage Examples

```bash
# Browse snapshot timeline
vaino timeline --since "2 weeks ago"

# List snapshots with details  
vaino history --provider kubernetes

# Inspect specific snapshot
vaino history show snapshot-123 --details

# Export as JSON
vaino timeline --output json
```

🤖 Generated with [Claude Code](https://claude.ai/code)