### PR TITLE
fix: Complete VAINO rebrand with consistent snapshot naming

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -177,18 +177,13 @@ func (dm *DefaultsManager) getDefaultAWSRegions() []string {
 
 // GenerateAutoName creates a meaningful name based on context
 func (dm *DefaultsManager) GenerateAutoName(prefix string) string {
-	// Get directory name
-	dirName := filepath.Base(dm.workingDir)
-
-	// Clean up the name
-	if dirName == "." || dirName == "/" {
-		dirName = "vaino"
-	}
+	// Use "vaino" as the product name for snapshot names
+	productName := "vaino"
 
 	// Add timestamp
 	timestamp := time.Now().Format("2006-01-02-15-04")
 
-	return fmt.Sprintf("%s-%s-%s", prefix, dirName, timestamp)
+	return fmt.Sprintf("%s-%s-%s", prefix, productName, timestamp)
 }
 
 // GetRecommendedStoragePath suggests storage path based on project context


### PR DESCRIPTION
## Summary
- Fix auto-generated snapshot names to consistently use "vaino" instead of directory names
- Ensures snapshot naming follows format: `scan-vaino-2025-07-12-03-16`
- Completes the final piece of the VAINO rebrand for user-facing output

## Test plan
- [x] Build and test snapshot generation with GCP scan
- [x] Verify naming format shows "vaino" instead of "wgo" or directory names  
- [x] Confirm existing functionality unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)