### PR TITLE
Remove misleading cost/security analysis and add separate Terraform codebase handling

### DIFF
--- a/internal/collectors/interface.go
+++ b/internal/collectors/interface.go
@@ -39,6 +39,15 @@ type EnhancedCollector interface {
 	SupportedRegions() []string
 }
 
+// MultiSnapshotCollector defines the interface for collectors that can create separate snapshots
+// Currently only implemented by Terraform collector for separate codebase handling
+type MultiSnapshotCollector interface {
+	EnhancedCollector
+
+	// CollectSeparate creates separate snapshots per logical unit (e.g., per Terraform codebase)
+	CollectSeparate(ctx context.Context, config CollectorConfig) ([]*types.Snapshot, error)
+}
+
 // CollectorInfo provides metadata about a collector
 type CollectorInfo struct {
 	Name        string   `json:"name"`

--- a/internal/output/scan_formatter.go
+++ b/internal/output/scan_formatter.go
@@ -251,22 +251,6 @@ func (f *ScanFormatter) FormatOutput() string {
 		output.WriteString("\n")
 	}
 
-	// Cost insights
-	costInsights := f.generateCostInsights(resourcesByType)
-	if costInsights != "" {
-		output.WriteString("💡 Cost insights:\n")
-		output.WriteString(costInsights)
-		output.WriteString("\n")
-	}
-
-	// Security insights
-	securityInsights := f.generateSecurityInsights(resourcesByType)
-	if securityInsights != "" {
-		output.WriteString("🔒 Security considerations:\n")
-		output.WriteString(securityInsights)
-		output.WriteString("\n")
-	}
-
 	// Next steps
 	output.WriteString("📌 Next steps:\n")
 	output.WriteString("  • Run 'vaino diff' to detect any drift\n")


### PR DESCRIPTION
## Summary
- Removed cost insights and security considerations from scan output as they were misleading
- Added `--separate-codebases` flag for Terraform to create individual snapshots per codebase
- Maintains backward compatibility with default unified view

## Changes Made

### 1. Removed Misleading Features
The scan output previously showed:
- 💰 Cost insights: Generic cost warnings without actual cost analysis
- 🔒 Security considerations: Security advice without real security scanning

These sections have been removed from `internal/output/scan_formatter.go` as VAINO is focused on drift detection, not cost/security analysis.

### 2. Added Separate Codebase Support
New functionality for Terraform provider:
- `--separate-codebases` flag creates individual snapshots per Terraform codebase
- Intelligent codebase detection based on directory structure
- Each codebase gets its own:
  - Unique snapshot ID: `terraform-{codebase-name}-{timestamp}`
  - Separate timeline tracking
  - Independent drift detection

### 3. Technical Implementation
- Added `MultiSnapshotCollector` interface extending `EnhancedCollector`
- Implemented `CollectSeparate()` method in Terraform collector
- Smart grouping of state files by their parent directories
- Separate output formatting showing each codebase individually

## Usage Examples

```bash
# Default unified view (unchanged)
vaino scan --provider terraform

# New separate mode
vaino scan --provider terraform --separate-codebases

# With multiple state files
vaino scan --provider terraform \
  --state-file project-a/terraform.tfstate \
  --state-file project-b/terraform.tfstate \
  --separate-codebases
```

## Output Comparison

### Before (Unified):
```
📊 Found 3 resources:
  aws_instance (1) - from project A
  aws_s3_bucket (1) - from project B  
  aws_lambda_function (1) - from project B
```

### After (Separate):
```
=== Codebase: project-a ===
📊 Found 1 resources:
  aws_instance (1)

=== Codebase: project-b ===
📊 Found 2 resources:
  aws_s3_bucket (1)
  aws_lambda_function (1)
```

## Test plan
- [x] Build passes
- [x] Tested unified mode still works as before
- [x] Tested separate mode creates individual snapshots
- [x] Verified each codebase snapshot saved independently
- [ ] Test with remote state files (S3, Azure, GCS)
- [ ] Test timeline/diff commands with separate snapshots

🤖 Generated with [Claude Code](https://claude.ai/code)