### PR TITLE
Fix: Honor --path flag for Terraform provider scanning

### DIFF
--- a/cmd/vaino/commands/scan.go
+++ b/cmd/vaino/commands/scan.go
@@ -277,7 +277,13 @@ func runScan(cmd *cobra.Command, args []string) error {
 		// Provider-specific configuration
 		switch provider {
 		case "terraform":
-			config.StatePaths = []string{"./terraform.tfstate", "./"}
+			// Check if --path flag was provided
+			path, _ := cmd.Flags().GetString("path")
+			if path != "" && path != "." {
+				config.StatePaths = []string{path}
+			} else {
+				config.StatePaths = []string{"./terraform.tfstate", "./"}
+			}
 		case "kubernetes":
 			// Get Kubernetes-specific flags
 			contexts, _ := cmd.Flags().GetStringSlice("context")


### PR DESCRIPTION
## Summary
• Fixes bug where --path flag was ignored for Terraform provider
• --path flag was defined but not used when configuring Terraform state paths
• Now properly uses user-specified path instead of hardcoded defaults

## Test plan
- [x] Verify --path flag is now respected for Terraform scanning
- [x] Confirm backward compatibility with default paths when --path not specified
- [x] Test that the fix resolves the original issue where Kubernetes was scanned instead of Terraform

🤖 Generated with [Claude Code](https://claude.ai/code)